### PR TITLE
Small typos in two propositional-logic/syntax-and-semantics (#196)

### DIFF
--- a/content/propositional-logic/syntax-and-semantics/formulas.tex
+++ b/content/propositional-logic/syntax-and-semantics/formulas.tex
@@ -41,8 +41,8 @@ above, we also use the following \emph{defined} symbols:
   \iftag{defOr}{\ycomma $\lor$ (disjunction)}{}%
   \iftag{defIf}{\ycomma $\lif$ (!!{conditional})}{}%
   \iftag{defIff}{\ycomma $\liff$ (!!{biconditional})}{}%
-  \iftag{defFalse}{\ycomma !!{falsity}~$\lfalse$}{}%
-  \iftag{defTrue}{\ycomma !!{truth}~$\ltrue$}.}{}
+  \iftag{defFalse}{\ycomma $\lfalse$ (!!{falsity})}{}%
+  \iftag{defTrue}{\ycomma $\ltrue$ (!!{truth})}.}{}
 
 \begin<defNot,defOr,defAnd,defIf,defIff,defTrue,defFalse,defEx,defAll>
   {explain}
@@ -67,9 +67,9 @@ for ``conjunction''.  Commonly used symbols for the ``conditional'' or
   or ``(material) equivalence'' are $\leftrightarrow$,
   $\Leftrightarrow$, and $\equiv$.}{}
 \iftag{prvFalse,defFalse}{The $\lfalse$ symbol is variously called
-  ``falsity,'' ``falsum,'', ``absurdity,'', or ``bottom.''}{}
+  ``falsity,'' ``falsum,'' ``absurdity,'' or ``bottom.''}{}
 \iftag{prvTrue,defTrue}{The $\ltrue$ symbol is variously called
-  ``truth,'' ``verum,'', or ``top.''}{}
+  ``truth,'' ``verum,'' or ``top.''}{}
 \end{intro}
 
 \begin{defn}[Formula]
@@ -98,12 +98,6 @@ is defined inductively as follows:
 
 \tagitem{prvIff}{If $!A$ and $!B$ are !!{formula}s, then $(!A \liff !B)$
   is a !!{formula}.}{}
-
-\tagitem{prvAll}{If $!A$ is a !!{formula} and $x$ is a !!{variable},
-  then $\lforall[x][!A]$ is a !!{formula}.}{}
-
-\tagitem{prvEx}{If $!A$ is a !!{formula} and $x$ is a !!{variable},
-  then $\lexists[x][!A]$ is a !!{formula}.}{}
 
 \tagitem{limitClause}{Nothing else is a !!{formula}.}{}
 \end{enumerate}

--- a/content/propositional-logic/syntax-and-semantics/introduction.tex
+++ b/content/propositional-logic/syntax-and-semantics/introduction.tex
@@ -14,8 +14,8 @@ Propositional logic deals with !!{formula}s that are built from
 !!{propositional variable}s using the propositional connectives
 $\lnot$, $\land$, $\lor$, $\lif$, and $\liff$.  Intuitively,
 !!a{propositional variable}~$p$ stands for a sentence or proposition
-that is be true or false. Whenever the ``truth value'' of the
-!!{propositional variable} in !!a{formula} are determined, so is the
+that is true or false. Whenever the ``truth value'' of the
+!!{propositional variable} in !!a{formula} is determined, so is the
 truth value of any !!{formula}s formed from them using propositional
 connectives.  We say that propositional logic is \emph{truth
   functional}, because its semantics is given by functions of truth
@@ -53,9 +53,9 @@ Giving the meaning of expressions is the domain of semantics.  The
 central concept in semantics for propositonal logic is that of
 satisfaction in !!a{valuation}. !!^a{valuation}~$\pAssign{v}$ assigns
 truth values $\True$, $\False$ to the !!{propositional variable}s. Any
-!!{valuation} determines a truth value $\pValue{v}{!A}$ for any
+!!{valuation} determines a truth value $\pValue{v}(!A)$ for any
 !!{formula}~$!A$.  !!^a{formula} is satisfied in
-!!a{valuation}~$\pAssign{v}$ iff $\pValue{v}{!A} = \True$---we write
+!!a{valuation}~$\pAssign{v}$ iff $\pValue{v}(!A) = \True$---we write
 this as $\pSat{v}{!A}$. This relation can also be defined by induction on
 the structure of~$!A$, using the truth functions for the logical
 connectives to define, say, satisfaction of $!A \land !B$ in terms of
@@ -65,7 +65,7 @@ On the basis of the satisfaction relation $\pSat{v}{!A}$ for sentences
 we can then define the basic semantic notions of tautology,
 entailment, and satisfiability.  !!^a{formula} is a tautology,
 $\Entails !A$, if every !!{valuation} satisfies it, i.e.,
-$\pValue{v}{!A} = \True$ for any~$\pAssign{v}$. It is entailed by a
+$\pValue{v}(!A) = \True$ for any~$\pAssign{v}$. It is entailed by a
 set of !!{formula}s, $\Gamma \Entails !A$, if every !!{valuation} that
 satisfies all the !!{formula}s in~$\Gamma$ also satisfies~$!A$. And a
 set of !!{formula}s is satisfiable if some !!{valuation} satisfies all

--- a/content/propositional-logic/syntax-and-semantics/preliminaries.tex
+++ b/content/propositional-logic/syntax-and-semantics/preliminaries.tex
@@ -35,7 +35,7 @@
   conditions of \olref[fml]{defn:formulas}: it contains all atomic
   !!{formula}s and is closed under the !!{operator}s.  $\Frm[L_0]$ is
   the smallest such class, so $\Frm[L_0] \subseteq S$. So $\Frm[L_0] = S$, and
-  every formula has propery~$P$.
+  every formula has property~$P$.
 \end{proof}
 
 \begin{prop}\ollabel{prop:balanced}
@@ -89,12 +89,12 @@ which is impossible by the inductive hypothesis.
 
 
 \begin{defn}[Uniform Substitution]
-If $!A$ and $!B$ are !!{formula}s, and $p_i$ is a propositional
-!!{variable}, then $\Subst{!A}{!B}{p_i}$ denotes the result of
-replacing each occurrence of $p_i$ by an occurrence of $!B$ in $!A$;
-similarly, the simultaneous substitution of $p_1$, \dots,~$p_n$ by
-!!{formula}s $!B_1$, \dots,~$\!B_n$ is denoted by
-$\SSubst{!A}{\subst{!B_1}{p_1},\dots,\subst{!B_n}{p_n}}$.
+If $!A$ and $!B$ are !!{formula}s, and $\Obj p_i$ is a propositional
+!!{variable}, then $\Subst{!A}{!B}{\Obj p_i}$ denotes the result of
+replacing each occurrence of $\Obj p_i$ by an occurrence of $!B$ in $!A$;
+similarly, the simultaneous substitution of $\Obj p_1$, \dots,~$\Obj p_n$ by
+!!{formula}s $!B_1$, \dots,~$!B_n$ is denoted by
+$\SSubst{!A}{\subst{!B_1}{\Obj p_1},\dots,\subst{!B_n}{\Obj p_n}}$.
 \end{defn}
 
 \begin{prob}

--- a/content/propositional-logic/syntax-and-semantics/valuations-sat.tex
+++ b/content/propositional-logic/syntax-and-semantics/valuations-sat.tex
@@ -19,65 +19,108 @@ function~$\pAssign{v}$ assigning either $\True$ or $\False$ to the
 \end{defn}
 
 \begin{defn}
-  Given a !!{valuation}~$v$, define the evaluation function
+  Given a !!{valuation}~$\pAssign{v}$, define the evaluation function
   $\pValue{v} \colon \Frm[L_0] \to \{\True, \False \}$ inductively by:
   \begin{align*}
-    \iftag{prvFalse}{\pValue{v}{\lfalse} & = \False; \\}{}
-    \iftag{prvTrue}{\pValue{v}{\ltrue} & = \True; \\}{}
-    \pValue{v}{\Obj p_n} & = \pAssign{v}(\Obj p_n); \\ 
-    \iftag{prvNot}{\pValue{v}{\lnot !A} & = \begin{cases}
-        \True & \text{if } \pValue{v}{!A} = \False;\\ 
+    \iftag{prvFalse}{\pValue{v}(\lfalse) & = \False; \\}{}
+    \iftag{prvTrue}{\pValue{v}(\ltrue) & = \True; \\}{}
+    \pValue{v}(\Obj p_n) & = \pAssign{v}(\Obj p_n); \\ 
+    \iftag{prvNot}{\pValue{v}(\lnot !A) & = \begin{cases}
+        \True & \text{if } \pValue{v}(!A) = \False;\\ 
         \False & \text{otherwise.} 
       \end{cases} \\ }{}
-    \iftag{prvAnd}{\pValue{v}{!A \land !B} & = \begin{cases} 
+    \iftag{prvAnd}{\pValue{v}(!A \land !B) & = \begin{cases} 
         \True &
-        \text{if $\pValue{v}{!A} = \True$ and $\pValue{v}{!B} = \True$;}\\
+        \text{if $\pValue{v}(!A) = \True$ and $\pValue{v}(!B) = \True$;}\\
         \False &
-        \text{if $\pValue{v}{!A} = \False$ or $\pValue{v}{!B} = \False$}.
+        \text{if $\pValue{v}(!A) = \False$ or $\pValue{v}(!B) = \False$}.
       \end{cases}\\}{}
-    \iftag{prvOr}{\pValue{v}{!A \lor !B} & = \begin{cases} 
+    \iftag{prvOr}{\pValue{v}(!A \lor !B) & = \begin{cases} 
         \True &
-        \text{if $\pValue{v}{!A} = \True$ or $\pValue{v}{!B} = \True$;}\\
+        \text{if $\pValue{v}(!A) = \True$ or $\pValue{v}(!B) = \True$;}\\
         \False &
-        \text{if $\pValue{v}{!A} = \False$ and $\pValue{v}{!B} = \False$}.
+        \text{if $\pValue{v}(!A) = \False$ and $\pValue{v}(!B) = \False$}.
       \end{cases}\\}{}
-    \iftag{prvIf}{\pValue{v}{!A \lif !B} & = \begin{cases} 
+    \iftag{prvIf}{\pValue{v}(!A \lif !B) & = \begin{cases} 
         \True &
-        \text{if $\pValue{v}{!A} = \False$ or $\pValue{v}{!B} = \True$;}\\
+        \text{if $\pValue{v}(!A) = \False$ or $\pValue{v}(!B) = \True$;}\\
         \False &
-        \text{if $\pValue{v}{!A} = \True$ and $\pValue{v}{!B} = \False$}.
+        \text{if $\pValue{v}(!A) = \True$ and $\pValue{v}(!B) = \False$}.
       \end{cases}\\}{}
-    \iftag{prvIff}{\pValue{v}{!A \liff !B} & = \begin{cases} 
+    \iftag{prvIff}{\pValue{v}(!A \liff !B) & = \begin{cases} 
         \True &
-        \text{if $\pValue{v}{!A} = \pValue{v}{!B}$;}\\
+        \text{if $\pValue{v}(!A) = \pValue{v}(!B)$;}\\
         \False &
-        \text{if $\pValue{v}{!A} \neq \pValue{v}{!B}$}.
+        \text{if $\pValue{v}(!A) \neq \pValue{v}(!B)$}.
       \end{cases}}{}
 \end{align*}
 \end{defn}
 
 
 \begin{explain} 
-The !!{valuation} clauses correspond to the following truth tables:
+The clauses correspond to the following truth tables:
 \begin{center}
-\begin{tabular}{|cc||c|c|c|c|} \hline 
-$!A$ & $!B$ & $!A \land !B$ & $!A \lor !B$ & $!A \lif !B$ & $!A \liff !B$\\ 
-\hline \hline 
-$\True$ & $\True$ & $\True$ & $\True$ & $\True$ & $\True$\\ 
-$\True$ & $\False$ & $\False$ & $\True$ & $\False$ & $\False$\\ 
-$\False$ & $\True$ & $\False$ & $\True$ & $\True$ & $\False$\\
-$\False$ & $\False$ & $\False$ & $\False$ & $\True$ & $\True$\\ 
-\hline 
-\end{tabular}
+\iftag{prvNot}{
+  \begin{tabular}{|c||c|} \hline 
+    $!A$ & $ \lnot !A$ \\ 
+    \hline \hline 
+    $\True$ & $\False$ \\ 
+    $\False$ & $\True$ \\ 
+    \hline 
+  \end{tabular}
+}{}
+\iftag{prvAnd}{
+  \begin{tabular}{|cc||c|} \hline 
+    $!A$ & $!B$ & $!A \land !B$ \\ 
+    \hline \hline 
+    $\True$ & $\True$ & $\True$ \\ 
+    $\True$ & $\False$ & $\False$ \\ 
+    $\False$ & $\True$ & $\False$ \\
+    $\False$ & $\False$ & $\False$ \\ 
+    \hline 
+  \end{tabular}
+}{}
+\iftag{prvOr}{
+  \begin{tabular}{|cc||c|} \hline 
+    $!A$ & $!B$ & $!A \lor !B$ \\ 
+    \hline \hline 
+    $\True$ & $\True$ & $\True$ \\ 
+    $\True$ & $\False$ & $\True$ \\ 
+    $\False$ & $\True$ & $\True$ \\
+    $\False$ & $\False$ & $\False$ \\ 
+    \hline 
+  \end{tabular}
+}{}\iftag{prvAnd,prvOr,prvIf,prvIff}{\\[1em]}{}
+\iftag{prvIf}{
+  \begin{tabular}{|cc||c|} \hline 
+    $!A$ & $!B$ & $!A \lif !B$ \\ 
+    \hline \hline 
+    $\True$ & $\True$ & $\True$ \\ 
+    $\True$ & $\False$ & $\False$ \\ 
+    $\False$ & $\True$ & $\True$ \\
+    $\False$ & $\False$ & $\True$ \\ 
+    \hline 
+  \end{tabular}
+}{}
+\iftag{prvIff}{
+  \begin{tabular}{|cc||c|} \hline 
+    $!A$ & $!B$ & $!A \liff !B$ \\ 
+    \hline \hline 
+    $\True$ & $\True$ & $\True$ \\ 
+    $\True$ & $\False$ & $\False$ \\ 
+    $\False$ & $\True$ & $\False$ \\
+    $\False$ & $\False$ & $\True$ \\ 
+    \hline 
+  \end{tabular}
+}{}
 \end{center} 
 \end{explain}
 
 \begin{thm} [Local Determination] 
 \ollabel{thm:LocalDetermination} Suppose that $\pAssign{v_1}$ and
 $\pAssign{v_2}$ are !!{valuation}s that agree on the propositional
-letters occurring in $!A$, i.e., $\pValue{v_1}{\Obj p_n} =
-\pValue{v_2}{\Obj p_n}$ whenever $\Obj p_n$ occurs in~$!A$. Then they
-also agree on any~$!A$, i.e., $\pValue{v_1}{!A} = \pValue{v_2}{!A}$.
+letters occurring in $!A$, i.e., $\pAssign{v_1}(\Obj p_n) =
+\pAssign{v_2}(\Obj p_n)$ whenever $\Obj p_n$ occurs in some !!{formula}~$!A$. Then $\pValue{v_1}$ and $\pValue{v_2}$ also agree on~$!A$, i.e., $\pValue{v_1}(!A) = \pValue{v_2}(!A)$.
 \end{thm}
 
 \begin{proof} 
@@ -97,12 +140,12 @@ define the notion of \emph{satisfaction of a !!{formula}~$!A$ by
 \tagitem{prvTrue}{%
   \indcase{!A}{\ltrue}{$\pSat{v}{\indfrm}$.}}{}
 
-\item \indcase{!A}{\Obj p_i}{$\pSat{M}{\indfrm}$
-  iff $\pValue{v}{\Obj p_i} = \True$.}
+\item \indcase{!A}{\Obj p_i}{$\pSat{v}{\indfrm}$
+  iff $\pAssign{v}(\Obj p_i) = \True$.}
 
 \tagitem{prvNot}{%
   \indcase{!A}{\lnot !B}{$\pSat{v}{\indfrm}$ iff
-    $\Sat/{v}{!B}$.}}{}
+    $\pSat/{v}{!B}$.}}{}
 
 \tagitem{prvAnd}{%
   \indcase{!A}{(!B \land !C)}{$\pSat{v}{\indfrm}$ iff $\pSat{v}{!B}$
@@ -126,7 +169,7 @@ $\pSat{v}{!A}$ for every~$!A \in \Gamma$.
 \end{defn}
 
 \begin{prop}\ollabel{prop:sat-value}
-  $\pSat{v}{!A}$ iff $\pValue{v}{!A} = \True$.
+  $\pSat{v}{!A}$ iff $\pValue{v}(!A) = \True$.
 \end{prop}
 
 \begin{proof}

--- a/open-logic-config.sty
+++ b/open-logic-config.sty
@@ -401,7 +401,12 @@
 
 % - `\pValue{v}{A}` - Truth value of a formula under a truth-value assignment.
 
-\DeclareDocumentCommand \pValue { m m }{\overline{\pAssign{#1}}(#2)}
+\DeclareDocumentCommand \pValue { m d() }{
+\IfNoValueTF {#2} {
+  \overline{\pAssign{#1}}}{
+  \overline{\pAssign{#1}}(#2)
+  }
+}
 
 % - `\pSat[/]{v}{!A}`, the relation of being satisfied by a
 % truth-value assignment


### PR DESCRIPTION
* Typos in formulas.tex

* Fixed two small typos in the first paragraph

* Typos + more flexible truth tables + redefine \pAssign to get the definition of evalutaion function correct.

* Fixed to \pAssign{}() in introduction.

* Changed to \pValue{}() in introduction.