### PR TITLE
Typos from beastaugh (#197)

### DIFF
--- a/content/normal-modal-logic/frame-definability/equivalence-S5.tex
+++ b/content/normal-modal-logic/frame-definability/equivalence-S5.tex
@@ -12,7 +12,7 @@
 
 The modal logic \Log{S5} is characterized as the set of !!{formula}s
 valid on all universal frames, i.e., every world is accessible from
-every world, including itself. In such a scenarion, $\Box$ corresponds
+every world, including itself. In such a scenario, $\Box$ corresponds
 to necessity and $\Diamond$ to possibility: $\Box !A$ is true if $!A$
 is true at \emph{every} world, and $\Diamond !A$ is true if $!A$ is
 true at \emph{some} world. It turns out that \Log{S5} can also be


### PR DESCRIPTION
* Correct typo in "First-order Definability" section of the normal
modal logic chapter "Frame definability".

* Fix typo in Equivalence Relations and S5 section.